### PR TITLE
bpo-42285: Add missing spaces after commas in list literals

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -229,14 +229,14 @@ in the context of the :keyword:`!for` and :keyword:`!if` clauses which follow it
 For example, this listcomp combines the elements of two lists if they are not
 equal::
 
-   >>> [(x, y) for x in [1,2,3] for y in [3,1,4] if x != y]
+   >>> [(x, y) for x in [1, 2, 3] for y in [3, 1, 4] if x != y]
    [(1, 3), (1, 4), (2, 3), (2, 1), (2, 4), (3, 1), (3, 4)]
 
 and it's equivalent to::
 
    >>> combs = []
-   >>> for x in [1,2,3]:
-   ...     for y in [3,1,4]:
+   >>> for x in [1, 2, 3]:
+   ...     for y in [3, 1, 4]:
    ...         if x != y:
    ...             combs.append((x, y))
    ...


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Adds missing spaces after commas in list literals in the tutorial. Makes it consistent with other list literals and compliant with the style section of the tutorial.

https://bugs.python.org/issue42285